### PR TITLE
Include <ostream> in mpLayer.h

### DIFF
--- a/include/mpLayer.h
+++ b/include/mpLayer.h
@@ -15,6 +15,7 @@
 #include <wx/gdicmn.h>
 #include <deque>
 #include <map>
+#include <ostream>
 #include "mathplot.h"
 
 


### PR DESCRIPTION
In a future version of MSVC, \<string> doesn't transitively include\<ostream>.
This port will compile failed with mpScaleY.cpp(146): error C2039: 'fabs': is not a member of 'std', so I add include\<ostream> into the header file.