### PR TITLE
Add missing headers to baseXYData.h.

### DIFF
--- a/include/baseXYData.h
+++ b/include/baseXYData.h
@@ -5,6 +5,9 @@
 #include "CMinMax.h"
 #include "xyMultimapLabel.h"
 #include <deque>
+#include <time.h>
+#include <vector>
+#include <limits>
 
 //This possible to handle a lot of data quicker
 //plot just second 1000 point to display..


### PR DESCRIPTION
On Ubuntu 22.04, this project no longer compiles, because `baseXYData.h` names `numeric_limits` without including `<limits>`. Also added `<time.h>` for `time_t` and `<vector>` for `vector`, as those were mentioned in this file.